### PR TITLE
meta.yaml: ask for jedi >= 0.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 1923af00820a8cf58e91d56b89efc59780a6e81363b94464a0f17c039dffff9e
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py<37]
   entry_points:
@@ -27,8 +27,7 @@ requirements:
     - backcall
     - colorama  # [win]
     - decorator
-    # TODO: unpin once fixed
-    - jedi >=0.10,<0.18
+    - jedi >=0.18
     - pexpect >4.3  # [unix]
     - pickleshare
     - prompt-toolkit !=3.0.0,!=3.0.1,<3.1.0,>=2.0.0


### PR DESCRIPTION
Fixes the issues described in 
https://github.com/ipython/ipython/issues/12813 now that the issues in
https://github.com/ipython/ipython/issues/12740 have been resolved (tab
completion would be unavailable for many packages).

Proposed MR for https://github.com/AnacondaRecipes/ipython-feedstock/issues/1. Not sure if asking for jedi >= 0.18 isn't actually too restrictive in practical terms.