### PR TITLE
ipython 7.28.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.27.0" %}
+{% set version = "7.28.0" %}
 
 {% set migrating = False %}
 {% set migrating = True %}  # [win and python_impl == 'pypy']
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/ipython/ipython-{{ version }}.tar.gz
-  sha256: 58b55ebfdfa260dad10d509702dc2857cb25ad82609506b070cf2d7b7df5af13
+  sha256: 2097be5c814d1b974aea57673176a924c4c8c9583890e7a5f082f547b9975b11
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - appnope  # [osx]
     - backcall

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,8 @@ test:
     - testpath
     - trio
     - ipykernel
+    # on aarch64 conda-build uses parso 0.7.0 and it causes the build failed
+    - parso >=0.8.0,<0.9.0  # [linux and aarch64]
     {% endif %}
 
   imports:


### PR DESCRIPTION
Update ipython to 7.28.0

Category:  anaconda | subcategory:  core | pkg_type:  python
Popularity:  8395095 downloads -  ipython  7.28.0  IPython: Productive Interactive Computing
Version change: bump version number from 7.27.0 to 7.28.0
  license: BSD-3-Clause
Release date:  Sep 25, 2021
Bug Tracker: new open issues https://github.com/ipython/ipython/issues
Releases:  https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#ipython-7-28
License file:  https://github.com/ipython/ipython/blob/master/LICENSE
Upstream setup.py:  https://github.com/ipython/ipython/blob/7.28.0/setup.py

Actions:
1. Add missing packages: `setuptools`, `wheel`

Result:
- errors in tests on `aarch64` platform
