### PR TITLE
ipython 7.31.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.31.0" %}
+{% set version = "7.31.1" %}
 
 {% set migrating = False %}
 {% set migrating = True %}  # [win and python_impl == 'pypy']
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/ipython/ipython-{{ version }}.tar.gz
-  sha256: 346c74db7312c41fa566d3be45d2e759a528dcc2994fe48aac1a03a70cd668a3
+  sha256: b5548ec5329a4bcf054a5deed5099b0f9622eb9ea51aaa7104d215fece201d8c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,11 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   skip: true  # [py<37]
+  script_env:
+    # Use MIGRATING environment variable instead of duplicating conditions into run_test.py.
+    # Combine script_env stanzas to avoid clobber
+    - MIGRATING={{ migrating }}
+    - IPYTHON_TESTING_TIMEOUT_SCALE=5
   entry_points:
     - ipython = IPython:start_ipython
     - ipython3 = IPython:start_ipython
@@ -32,7 +37,7 @@ requirements:
     - backcall
     - colorama  # [win]
     - decorator
-    - jedi >=0.16,<1.0
+    - jedi >=0.16
     # earlier versions depended on ipython
     - matplotlib-inline >=0.1.2
     - pexpect >4.3  # [unix]
@@ -48,15 +53,15 @@ test:
     - pip
     {% if not migrating %}
     - curio  # [unix]
+    - ipykernel
     - matplotlib-base
     - nbformat
     - nose >=0.10.1
-    - numpy
-    - pygments
+    - numpy >=1.17
+    - pytest
     - requests
     - testpath
     - trio
-    - ipykernel
     {% endif %}
 
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.29.0" %}
+{% set version = "7.31.0" %}
 
 {% set migrating = False %}
 {% set migrating = True %}  # [win and python_impl == 'pypy']
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/ipython/ipython-{{ version }}.tar.gz
-  sha256: 4f69d7423a5a1972f6347ff233e38bbf4df6a150ef20fbb00c635442ac3060aa
+  sha256: 346c74db7312c41fa566d3be45d2e759a528dcc2994fe48aac1a03a70cd668a3
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,7 @@ test:
     - nose >=0.10.1
     - numpy >=1.17
     - pytest
+    - pygments
     - requests
     - testpath
     - trio

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -6,9 +6,10 @@ import sys
 WIN = platform.system() == "Windows"
 LINUX = platform.system() == "Linux"
 PYPY = "__pypy__" in sys.builtin_module_names
+PPC = "ppc" in platform.machine()
 
-# TODO: remove when all test dependencies are available on pypy37 for Windows
-MIGRATING = WIN and PYPY
+# Environment variable should be set in the meta.yaml
+MIGRATING = eval(os.environ.get("MIGRATING", "None"))
 
 # this is generally failing, for whatever reason
 NOSE_EXCLUDE = ["recursion"]
@@ -21,6 +22,9 @@ else:
 if LINUX:
     # https://github.com/ipython/ipython/issues/12164
     NOSE_EXCLUDE += ["system_interrupt"]
+
+if PPC:
+    NOSE_EXCLUDE += ["ipython_dir_8", "audio_data"]
 
 IPTEST_ARGS = []
 


### PR DESCRIPTION
Version change: bump version number from 7.29.0 to 7.31.1
Changelog: https://ipython.readthedocs.io/en/stable/whatsnew/version7.html#ipython-7-31
Bug Tracker: new open issues https://github.com/ipython/ipython/issues
Upstream license:  License file:  https://github.com/ipython/ipython/blob/master/LICENSE
Upstream setup.py:  https://github.com/ipython/ipython/blob/7.31.1/setup.py

Actions:
1. Add script_env:
```
  script_env:
    # Use MIGRATING environment variable instead of duplicating conditions into run_test.py.
    # Combine script_env stanzas to avoid clobber
    - MIGRATING={{ migrating }}
    - IPYTHON_TESTING_TIMEOUT_SCALE=5
```
2. Update run dependencies
3. Add `pytest `to test/requires
4. Update run_test.py

Result:
- all-succeeded