### PR TITLE
Rebuild ipython 7.31.1 for python support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: b5548ec5329a4bcf054a5deed5099b0f9622eb9ea51aaa7104d215fece201d8c
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   skip: true  # [py<37]
   script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,16 +52,13 @@ test:
   requires:
     - pip
     {% if not migrating %}
-    - curio  # [unix]
     - ipykernel
-    - matplotlib-base
     - nbformat
     - nose >=0.10.1
     - numpy >=1.17
-    - pytest
+    - pygments
     - requests
     - testpath
-    - trio
     {% endif %}
 
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
 
 test:
   requires:
-    - python <3.10.3
+    - python <3.10.1
     - pip
     {% if not migrating %}
     - curio  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,13 +52,17 @@ test:
   requires:
     - pip
     {% if not migrating %}
+    - curio  # [unix]
     - ipykernel
+    - matplotlib-base
     - nbformat
     - nose >=0.10.1
     - numpy >=1.17
+    - pytest
     - pygments
     - requests
     - testpath
+    - trio
     {% endif %}
 
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,6 @@ requirements:
 
 test:
   requires:
-    - python <3.10.1
     - pip
     {% if not migrating %}
     - curio  # [unix]
@@ -60,7 +59,6 @@ test:
     - nose >=0.10.1
     - numpy >=1.17
     - pytest
-    - pygments
     - requests
     - testpath
     - trio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ requirements:
 
 test:
   requires:
+    - python <3.10.3
     - pip
     {% if not migrating %}
     - curio  # [unix]


### PR DESCRIPTION
spyder 5.2.2 requires ipython >=7.6,<8.0 so we have to add python 3.10 support to ipython 7.31.1 (the latest version in 7.31 branch)