### PR TITLE
V8.12.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ipython" %}
-{% set version = "8.14.0" %}
+{% set version = "8.12.2" %}
 {% set migrating = false %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1d197b907b6ba441b692c48cf2a3a2de280dc0ac91a3405b39349a50272ca0a1
+  sha256: c7b80eb7f5a855a88efc971fda506ff7a91c280b42cdae26643e0f601ea281ea
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ipython" %}
-{% set version = "8.12.0" %}
+{% set version = "8.14.0" %}
 {% set migrating = false %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a950236df04ad75b5bc7f816f9af3d74dc118fd42f2ff7e80e8e60ca1f182e2d
+  sha256: 1d197b907b6ba441b692c48cf2a3a2de280dc0ac91a3405b39349a50272ca0a1
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<38]
   script_env:
     - MIGRATING={{ migrating }}


### PR DESCRIPTION
[Upstream](https://github.com/ipython/ipython)

Very minor bump to support [spyder-kernels-2.4.4](https://github.com/AnacondaRecipes/spyder-kernels-feedstock/pull/14)

# Note:
- This is the last version of `ipython` that supports `python 3.8`