### PR TITLE
ipython 8.25.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+channels:
+  - https://staging.continuum.io/prefect/fs/traitlets-feedstock/pr6/a863426

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "ipython" %}
 {% set version = "8.25.0" %}
-{% set migrating = false %}
 
 package:
   name: {{ name|lower }}
@@ -14,8 +13,6 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<310]
-  script_env:
-    - MIGRATING={{ migrating }}
   entry_points:
     - ipython = IPython:start_ipython
     - ipython3 = IPython:start_ipython
@@ -43,7 +40,6 @@ requirements:
 test:
   requires:
     - pip
-    {% if not migrating %}
     - pytest
     - pytest-asyncio <0.22
     - testpath
@@ -54,7 +50,6 @@ test:
     - numpy >=1.23
     - pandas
     - trio
-    {% endif %}
   commands:
     - pip check
     - pygmentize -L | grep ipython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,14 +37,14 @@ requirements:
     - prompt_toolkit >=3.0.41,<3.1.0
     - pygments >=2.4.0
     - stack_data
-    - traitlets >=5
+    - traitlets >=5.13.0
+    - typing_extensions >=4.6 # [py<312]
 
 test:
   requires:
     - pip
     {% if not migrating %}
-    - pytest <7.1  # [py<312]
-    - pytest  # [py>=312]
+    - pytest
     - pytest-asyncio <0.22
     - testpath
     - pickleshare
@@ -53,11 +53,8 @@ test:
     - nbformat
     - numpy >=1.23
     - pandas
-    - pygments
-    - pytest-cov
     - trio
     {% endif %}
-
   commands:
     - pip check
     - pygmentize -L | grep ipython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
     - pygmentize -L | grep ipython
     - ipython -h
     - ipython3 -h
-    - export MIGRATING=false
+    - export MIGRATING=false  # [unix]
 
 about:
   home: https://ipython.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ipython" %}
-{% set version = "8.20.0" %}
+{% set version = "8.25.0" %}
 {% set migrating = false %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2f21bd3fc1d51550c89ee3944ae04bbc7bc79e129ea0937da6e6c68bfdbf117a
+  sha256: c6ed726a140b6e725b911528f80439c534fac915246af3efc39440a6b0f9d716
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,6 @@ build:
   skip: true  # [py<310]
   script_env:
     - MIGRATING={{ migrating }}
-    # TODO: investigate removing when some pypy/coverage speed issues are resolved
-    - COV_THRESHOLD=50
   entry_points:
     - ipython = IPython:start_ipython
     - ipython3 = IPython:start_ipython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ test:
     - pygmentize -L | grep ipython
     - ipython -h
     - ipython3 -h
+    - export MIGRATING=false
 
 about:
   home: https://ipython.org

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -2,24 +2,6 @@ import subprocess
 import platform
 import os
 import sys
-import IPython
-import IPython.core
-import IPython.core.magics
-import IPython.core.tests
-import IPython.extensions
-import IPython.extensions.tests
-import IPython.external
-import IPython.lib
-import IPython.lib.tests
-import IPython.sphinxext
-import IPython.terminal
-import IPython.terminal.pt_inputhooks
-import IPython.terminal.tests
-import IPython.testing
-import IPython.testing.plugin
-import IPython.testing.tests
-import IPython.utils.tests
-import IPython.utils
 
 WIN = platform.system() == "Windows"
 LINUX = platform.system() == "Linux"

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -2,6 +2,8 @@ import subprocess
 import platform
 import os
 import sys
+from pathlib import Path
+import IPython
 
 WIN = platform.system() == "Windows"
 LINUX = platform.system() == "Linux"
@@ -14,7 +16,18 @@ COV_THRESHOLD = os.environ.get("COV_THRESHOLD")
 MIGRATING = eval(os.environ.get("MIGRATING", "None"))
 
 PYTEST_SKIPS = ["decorator_skip", "pprint_heap_allocated"]
-PYTEST_ARGS = [sys.executable, "-m", "pytest", "--pyargs", "IPython", "-vv"]
+PYTEST_ARGS = [sys.executable, "-m", "pytest", "-vv"]
+
+IGNORE_GLOBS = [
+    "consoleapp.py",
+    "external/*.py",
+    "sphinxext/*.py",
+    "terminal/console*.py",
+    "terminal/pt_inputhooks/*.py",
+    "utils/*.py",
+]
+
+PYTEST_ARGS += sum([[f"--ignore-glob", glob] for glob in IGNORE_GLOBS], [])
 
 if WIN:
     pass
@@ -25,7 +38,7 @@ if LINUX:
     PYTEST_SKIPS += ["system_interrupt"]
 
 if PPC:
-    PYTEST_SKIPS += ["ipython_dir_8", "audio_data", "figure_to_svg", "figure_to_jpeg", "retina_figure", "select_figure_formats_kwargs", "test_debug_magic_passes_through_generators"]
+    PYTEST_SKIPS += ["ipython_dir_8", "audio_data"]
 
 if len(PYTEST_SKIPS) == 1:
     PYTEST_ARGS += ["-k", f"not {PYTEST_SKIPS[0]}"]
@@ -33,9 +46,9 @@ elif PYTEST_SKIPS:
     PYTEST_ARGS += ["-k", f"""not ({" or ".join(PYTEST_SKIPS) })"""]
 
 if __name__ == "__main__":
-    print("Building on Windows?", WIN)
-    print("Building on Linux?  ", LINUX)
-    print("Building for PyPy?  ", PYPY)
+    print("Building on Windows?      ", WIN)
+    print("Building on Linux?        ", LINUX)
+    print("Building for PyPy?        ", PYPY)
 
     if MIGRATING:
         print("This is a migration, skipping test suite! Put it back later!", flush=True)
@@ -43,4 +56,4 @@ if __name__ == "__main__":
     else:
         print("Running pytest with args")
         print(PYTEST_ARGS, flush=True)
-        sys.exit(subprocess.call(PYTEST_ARGS))
+        sys.exit(subprocess.call(PYTEST_ARGS, cwd=str(Path(IPython.__file__).parent)))

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -45,12 +45,6 @@ if LINUX:
 if PPC:
     PYTEST_SKIPS += ["ipython_dir_8", "audio_data", "figure_to_svg", "figure_to_jpeg", "retina_figure", "select_figure_formats_kwargs", "test_debug_magic_passes_through_generators"]
 
-if COV_THRESHOLD is not None:
-    PYTEST_ARGS += [
-        "--cov", "IPython", "--no-cov-on-fail", "--cov-fail-under", COV_THRESHOLD,
-        "--cov-report", "term-missing:skip-covered"
-    ]
-
 if len(PYTEST_SKIPS) == 1:
     PYTEST_ARGS += ["-k", f"not {PYTEST_SKIPS[0]}"]
 elif PYTEST_SKIPS:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -37,9 +37,6 @@ else:
 if LINUX:
     PYTEST_SKIPS += ["system_interrupt"]
 
-if PPC:
-    PYTEST_SKIPS += ["ipython_dir_8", "audio_data"]
-
 if len(PYTEST_SKIPS) == 1:
     PYTEST_ARGS += ["-k", f"not {PYTEST_SKIPS[0]}"]
 elif PYTEST_SKIPS:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -46,11 +46,6 @@ if __name__ == "__main__":
     print("Building on Windows?      ", WIN)
     print("Building on Linux?        ", LINUX)
     print("Building for PyPy?        ", PYPY)
-
-    if MIGRATING:
-        print("This is a migration, skipping test suite! Put it back later!", flush=True)
-        sys.exit(0)
-    else:
-        print("Running pytest with args")
-        print(PYTEST_ARGS, flush=True)
-        sys.exit(subprocess.call(PYTEST_ARGS, cwd=str(Path(IPython.__file__).parent)))
+    print("Running pytest with args")
+    print(PYTEST_ARGS, flush=True)
+    sys.exit(subprocess.call(PYTEST_ARGS, cwd=str(Path(IPython.__file__).parent)))


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4933](https://anaconda.atlassian.net/browse/PKG-4933)
- [Upstream repository](https://github.com/ipython/ipython/tree/8.25.0)
- [Upstream changelog/diff](https://ipython.readthedocs.io/en/8.25.0/whatsnew/version8.html)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/traitlets-feedstock/pull/6

### Explanation of changes:

- Set version and sha256
- Remove outdated test parameters
- Dependency cleanup in test and run sections
- Sync `run_test.py` with conda forge version


[PKG-4933]: https://anaconda.atlassian.net/browse/PKG-4933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ