### PR TITLE
ipython 8.25.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/traitlets-feedstock/pr6/a863426


### PR DESCRIPTION
Same as https://github.com/AnacondaRecipes/ipython-feedstock/pull/43 with the abs.yaml removed