### PR TITLE
ipython 9.7.0: add py314 support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/matplotlib-inline-feedstock/pr4/240189b

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,5 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/pbp/fs/matplotlib-inline-feedstock/pr4/240189b
+  - https://staging.continuum.io/pbp/fs/parso-feedstock/pr4/0534e90
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/matplotlib-inline-feedstock/pr4/240189b
-  - https://staging.continuum.io/pbp/fs/parso-feedstock/pr4/0534e90
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,8 @@ test:
     - ipython3 -h
     - export MIGRATING=false  # [unix]
     # Newly added raise_on_interrupt tests failing
-    - pytest tests -k "not (timeit_raise_on_interrupt or script_raise_on_interrupt or time_raise_on_interrupt)"
+    # test_hist_file_config can fail randomly on osx-arm64 on CI
+    - pytest tests -k "not (timeit_raise_on_interrupt or script_raise_on_interrupt or time_raise_on_interrupt or test_hist_file_config)"
 
 about:
   home: https://ipython.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,10 +53,10 @@ test:
 # If test_extra: "yes" test all tests; otherwise test only the base tests for a new python version, e.g., py314.
 {% if test_extra == 'yes' %}
     - curio
-    - ipykernel >6.30  # [not py==314]
+    - ipykernel >6.30
     # jupyter_ai is not available yet on the main channel
     #- jupyter_ai
-    - matplotlib-base >3.9.0  # [not py==314]
+    - matplotlib-base >3.9.0
     - nbclient
     - nbformat
     - numpy >=1.27

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,9 @@
 {% set name = "ipython" %}
-{% set version = "9.5.0" %}
+{% set version = "9.7.0" %}
+# When building out the initial package set for a new Python version the
+# recommendation is to run basic tests only, then build
+# matplotlib-base, pandas, trio,ipykernel, etc. and then run with `test_extra="yes"` to test all the tests.
+{% set test_extra = "no" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +11,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 129c44b941fe6d9b82d36fc7a7c18127ddb1d6f02f78f867f402e2e3adde3113
+  sha256: 5f6de88c905a566c6a9d6c400a8fed54a638e1f7543d17aae2551133216b1e4e
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<311]
   entry_points:
@@ -21,19 +25,18 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - setuptools >=77.0
   run:
     - python
-    - colorama  # [win]
-    - decorator
-    - ipython_pygments_lexers
-    - jedi >=0.16
-    - matplotlib-inline
+    - colorama >=0.4.4  # [win]
+    - decorator >=4.3.2
+    - ipython_pygments_lexers >=1.0.0
+    - jedi >=0.18.1
+    - matplotlib-inline >=0.1.5
     - pexpect >4.3  # [not win]
     - prompt_toolkit >=3.0.41,<3.1.0
-    - pygments >=2.4.0
-    - stack_data
+    - pygments >=2.11.0
+    - stack_data >=0.6.0
     - traitlets >=5.13.0
     - typing_extensions >=4.6  # [py<312]
 
@@ -42,19 +45,24 @@ test:
     - tests
   requires:
     - pip
-    - pytest
-    - pytest-asyncio <0.22
-    - testpath
-    - pickleshare
+    - packaging >=20.1.0
+    - pytest >=7.0.0
+    - pytest-asyncio >=1.0.0
+    - setuptools >=61.2
+    - testpath >=0.2
+# If test_extra: "yes" test all tests; otherwise test only tha base tests for a new python version, e.i., py314.
+{% if test_extra == 'yes' %}
     - curio
-    - ipykernel
-    - matplotlib-base !=3.2.0
+    - ipykernel >6.30  # [not py==314]
+    # jupyter_ai is not available yet on the main channel
+    #- jupyter_ai
+    - matplotlib-base >3.9.0  # [not py==314]
     - nbclient
     - nbformat
-    - numpy >=1.23
-    - pandas
-    - trio
-    - python
+    - numpy >=1.27
+    - pandas >2.1
+    - trio >=0.1.0
+{% endif %}
   commands:
     - pip check
     - pygmentize -L | grep ipython  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - pytest-asyncio >=1.0.0
     - setuptools >=61.2
     - testpath >=0.2
-# If test_extra: "yes" test all tests; otherwise test only tha base tests for a new python version, e.i., py314.
+# If test_extra: "yes" test all tests; otherwise test only the base tests for a new python version, e.g., py314.
 {% if test_extra == 'yes' %}
     - curio
     - ipykernel >6.30  # [not py==314]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 129c44b941fe6d9b82d36fc7a7c18127ddb1d6f02f78f867f402e2e3adde3113
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<311]
   entry_points:
@@ -35,7 +35,7 @@ requirements:
     - pygments >=2.4.0
     - stack_data
     - traitlets >=5.13.0
-    - typing_extensions >=4.6 # [py<312]
+    - typing_extensions >=4.6  # [py<312]
 
 test:
   source_files:
@@ -69,7 +69,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: 'IPython: Productive Interactive Computing'
+  summary: "IPython: Productive Interactive Computing"
   description: |
     IPython provides a rich architecture for interactive computing with
     a powerful interactive shell, a kernel for Jupyter, high performance


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-10532) 
- [Upstream repository](https://github.com/ipython/ipython/tree/9.7.0)

### Explanation of changes:

- Do not run `test_extra` for a new Python 3.14 to resolve cyclic dependency with ipykernel
- Update pinnings in host, run and test.requires
- Skip flaky test_hist_file_config

### Notes:

-